### PR TITLE
minor fix for parse error on decimal fractions in scientific notation with exponent

### DIFF
--- a/pylibconfig2/parsing.py
+++ b/pylibconfig2/parsing.py
@@ -4,7 +4,7 @@ Knowledge on pyparsing and libconfig required =)
 """
 
 from pyparsing import alphas, alphanums, cppStyleComment, Combine, Group, \
-    Forward, hexnums, ParseException, ParseFatalException, pythonStyleComment, \
+    Forward, hexnums, nums, ParseException, ParseFatalException, pythonStyleComment, \
     oneOf, OneOrMore, Optional, QuotedString, Suppress, Word, ZeroOrMore, \
     stringStart, stringEnd
 from conf_types import ConfArray, ConfError, ConfGroup, ConfList
@@ -66,7 +66,7 @@ def convert_group(tokens):
 val_bool = Word("TRUEFALStruefals")\
     .setParseAction(convert_bool)
 val_num = Combine(
-    Optional(oneOf("+ -")) + Optional("0x") + Word(hexnums + ".eEL"))\
+    Optional(oneOf("+ -")) + Optional("0x") + Word(hexnums + ".eEL" + "-" + nums) )\
     .setParseAction(convert_num)
 val_str = OneOrMore(QuotedString('"', escChar='\\'))\
     .setParseAction(lambda t: "".join(t))


### PR DESCRIPTION
I'm not quite confident with pyparsing, but seems parser isn't working well with numbers like '-1.3e-15', my fellow scientist tripped over it while working with some calculus in python.
A simple fix worked for me but of course you, as the author, could make it better if needed.
