### PR TITLE
+ python3 compatibility, + setup() method

### DIFF
--- a/pylibconfig2/__init__.py
+++ b/pylibconfig2/__init__.py
@@ -1,10 +1,10 @@
-from conf_types import \
+from pylibconfig2.conf_types import \
     Config, \
     ConfError, \
     ConfGroup, \
     ConfList, \
     ConfArray
-from parsing import \
+from pylibconfig2.parsing import \
     ParseException, \
     ParseFatalException
 

--- a/pylibconfig2/conf_types.py
+++ b/pylibconfig2/conf_types.py
@@ -44,7 +44,7 @@ class _ListType(list):
 
     def _lookup(self, keys):
         k = self.array_index.parseString(keys.pop(0))[0]
-        if k and k < len(self):
+        if k < len(self):
             val = self[k]
             if not len(keys):
                 return val

--- a/pylibconfig2/conf_types.py
+++ b/pylibconfig2/conf_types.py
@@ -53,6 +53,14 @@ class _ListType(list):
                 return val
             if isinstance(val, (_ListType, ConfGroup)):
                 return val._lookup(keys)
+                
+    def _setup(self, keys, value):
+        k = self.array_index.parseString(keys.pop(0))[0]
+        if type(k) == int and k >= 0 and k < len(self):
+            if not len(keys):
+                self[k] = value
+            elif isinstance(self[k], (_ListType, ConfGroup)):
+                return self[k]._setup(keys, value)
 
     def __add__(self, y):
         raise ConfError("__add__ is not supported.")
@@ -169,6 +177,14 @@ class ConfGroup(object):
                 return val
             if isinstance(val, (_ListType, ConfGroup)):
                 return val._lookup(keys)
+                
+    def _setup(self, keys, value):
+        k = keys.pop(0)
+        if k in self.__dict__:
+            if not len(keys):
+                self.__dict__[k] = value
+            elif isinstance(self.__dict__[k], (_ListType, ConfGroup)):
+                return self.__dict__[k]._setup(keys, value)
 
     def __init__(self, ini_dict=None):
         if type(ini_dict) == dict:
@@ -246,6 +262,9 @@ class Config(ConfGroup):
     def lookup(self, key, default=None):
         res = self._lookup(key.split('.'))
         return res if res else default
+        
+    def setup(self, key, value):
+        self._setup(key.split('.'), value)
 
     def __init__(self, string):
         res = config.parseString(string)[0]

--- a/pylibconfig2/conf_types.py
+++ b/pylibconfig2/conf_types.py
@@ -153,13 +153,13 @@ class ConfGroup(object):
         return setattr(self, key, value)
 
     def keys(self):
-        return self.__dict__.keys()
+        return list(self.__dict__.keys())
 
     def values(self):
-        return self.__dict__.values()
+        return list(self.__dict__.values())
 
     def items(self):
-        return self.__dict__.items()
+        return list(self.__dict__.items())
 
     def _lookup(self, keys):
         k = keys.pop(0)
@@ -172,7 +172,7 @@ class ConfGroup(object):
 
     def __init__(self, ini_dict=None):
         if type(ini_dict) == dict:
-            for k, v in ini_dict.iteritems():
+            for k, v in ini_dict.items():
                 setattr(self, k, v)
 
     def __setattr__(self, key, val):
@@ -181,10 +181,10 @@ class ConfGroup(object):
     def __repr__(self):
         return "{\n  " + "\n  ".join(
             "%s = %s;" % (k, _format_string(v))
-            for k, v in self.__dict__.iteritems()
+            for k, v in self.__dict__.items()
         ) + "\n}"
 
-_scalar_types = str, int, long, float, bool
+_scalar_types = str, int, int, float, bool
 _all_types = _scalar_types + (ConfGroup, ConfList, ConfArray)
 
 
@@ -254,5 +254,5 @@ class Config(ConfGroup):
     def __repr__(self):
         return "\n".join(
             "%s = %s;" % (k, _format_string(v))
-            for k, v in self.__dict__.iteritems()
+            for k, v in self.__dict__.items()
         ).replace("\n  ", "\n")  # fix wrong indentation for grouped types

--- a/pylibconfig2/conf_types.py
+++ b/pylibconfig2/conf_types.py
@@ -7,6 +7,9 @@ ConfArray and ConfList extend the python list type. ConfGroup uses __dict__ as
  its data storage.
 """
 import pyparsing as pp
+import sys
+if sys.version > '3':
+    long = int
 
 class ConfError(Exception):
     pass
@@ -181,7 +184,6 @@ class ConfGroup(object):
             for k, v in self.__dict__.iteritems()
         ) + "\n}"
 
-
 _scalar_types = str, int, long, float, bool
 _all_types = _scalar_types + (ConfGroup, ConfList, ConfArray)
 
@@ -198,7 +200,7 @@ def _check_value(val):
     return val
 
 
-from parsing import ParseException, name
+from pylibconfig2.parsing import ParseException, name
 def _check_name(key):
     try:
         name.parseString(key)
@@ -214,7 +216,7 @@ def _format_string(obj):
         return repr(obj).replace("\n", "\n  ")
 
 
-from parsing import config
+from pylibconfig2.parsing import config
 class Config(ConfGroup):
     """
     Config represents a libconfig configuration.

--- a/pylibconfig2/parsing.py
+++ b/pylibconfig2/parsing.py
@@ -7,7 +7,7 @@ from pyparsing import alphas, alphanums, cppStyleComment, Combine, Group, \
     Forward, hexnums, ParseException, ParseFatalException, pythonStyleComment, \
     oneOf, OneOrMore, Optional, QuotedString, Suppress, Word, ZeroOrMore, \
     stringStart, stringEnd
-from conf_types import ConfArray, ConfError, ConfGroup, ConfList
+from pylibconfig2.conf_types import ConfArray, ConfError, ConfGroup, ConfList
 from ast import literal_eval
 
 assign = Suppress(oneOf(": ="))

--- a/pylibconfig2/parsing.py
+++ b/pylibconfig2/parsing.py
@@ -12,7 +12,7 @@ from ast import literal_eval
 
 assign = Suppress(oneOf(": ="))
 delim = Suppress(Optional(";"))
-lpar, rpar, lbrk, rbrk, lbrc, rbrc, comma = map(Suppress, "()[]{},")
+lpar, rpar, lbrk, rbrk, lbrc, rbrc, comma = list(map(Suppress, "()[]{},"))
 
 name = Word(alphas+"*", alphanums+"-_*")("name")
 value = Forward()


### PR DESCRIPTION
I just used 2to3 script and added setter, which needed badly. Could be useful in case someone stores keys as strings somewhere.
Seems that backward compatibility is not broken, checked in python 2.7.

Try any of this if you find it useful. Sorry if I'm bothering you too much, just came across the problem where your library is required a lot =)