### PR TITLE
Fix bug when parsing boolean value false

### DIFF
--- a/pylibconfig2/parsing.py
+++ b/pylibconfig2/parsing.py
@@ -63,14 +63,14 @@ def convert_group(tokens):
     return ConfGroup(dic)
 
 # scalar values
-val_bool = Word("TRUEFALStruefals")\
+val_bool = Word("TRUEFALSEtruefalse")\
     .setParseAction(convert_bool)
+val_str = OneOrMore(QuotedString('"', escChar='\\'))\
+    .setParseAction(lambda t: "".join(t))
 val_num = Combine(
     Optional(oneOf("+ -")) + Optional("0x") + Word(hexnums + ".eEL" + "+-") )\
     .setParseAction(convert_num)
-val_str = OneOrMore(QuotedString('"', escChar='\\'))\
-    .setParseAction(lambda t: "".join(t))
-val_scalar = (val_str | val_num | val_bool)
+val_scalar = val_bool | (val_str | val_num)
 
 # container values
 val_array = ArrayGroup(

--- a/pylibconfig2/test/test.py
+++ b/pylibconfig2/test/test.py
@@ -33,7 +33,7 @@ inp_2 = """
 // File with extraneous whitespace.
 
     foo = 1;
-
+toto = true;
 
 
 	bar
@@ -53,6 +53,7 @@ outp_2 = """
 foo = 1;
 bar = "Hello, world!";
 baz = 2;
+toto= true;
 """
 
 inp_3 = """
@@ -73,7 +74,7 @@ inp_4 = """
 // Last line has whitespace but no trailing newline.
 
 foo = 1;
-
+toto= false;
 
 bar = 2;
 
@@ -81,6 +82,7 @@ bar = 2;
 outp_4 = """
 foo = 1;
 bar = 2;
+toto = false;
 """
 
 


### PR DESCRIPTION

Hi, 

I'm actually testing your pylicbconfig2 to replace a native/boost-python implementation we use at work 
In top of it, I coded a "preprocessor" function, to handle includes because our files are big and use that feature ...
If you feel it's something that could benefit the lib, I would be glad to share it.

In the process, I came across what I think is a bug with the handling of false as boolean, where the parser believe it's the start of an hexadecimal number.

The completed test and the fix are in this patch.
